### PR TITLE
Add basic calendar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 site
 .venv
+.idea/

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,3 +21,12 @@ Feel free to send Pull Requests to update the content!
 
 Site is built with [mkdocs](https://www.mkdocs.org) with the
 [Material Design](https://squidfunk.github.io/mkdocs-material/) theme.
+
+# Events
+This list showcases upcoming UK student-run hackathons.
+
+|Hackathon        |Website| University         |No. of Hackers|Date|
+|-----------------|-------|--------------------|--------------|----|
+| DurHack 2019    | [durhack.com](https://durhack.com) | Durham University | 150 | 23rd-24th November 2019 |
+
+Want to add something to this list? [Fork and pull request](https://github.com/bahorn/hack.athon.uk/edit/master/docs/index.md) to add your event!


### PR DESCRIPTION
Add a basic calendar table on the homepage, into which people can PR their own events.

**Screenshot**
<img width="794" alt="image" src="https://user-images.githubusercontent.com/5098748/68246776-69576280-0011-11ea-9902-73cdf2bbffcb.png">
